### PR TITLE
Add @Configuration to class with @EnableMethodSecurity

### DIFF
--- a/adding-spring-security/leaveapp-complete/src/main/java/com/jdriven/leaverequest/MethodSecurityConfig.java
+++ b/adding-spring-security/leaveapp-complete/src/main/java/com/jdriven/leaverequest/MethodSecurityConfig.java
@@ -1,7 +1,9 @@
 package com.jdriven.leaverequest;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
+@Configuration
 @EnableMethodSecurity(jsr250Enabled = true)
 class MethodSecurityConfig {
 }


### PR DESCRIPTION
Add @Configuration to class with @EnableMethodSecurity. In Spring Boot 3.0 the @Configuration annotation will no longer be a meta-annotation of @EnableMethodSecurity